### PR TITLE
Disable DNS negative cache

### DIFF
--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -61,18 +61,26 @@ Configuration CFWindows {
       }
     }
 
-    Script DisableDNSCache
+    Script ClearDNSCache
     {
-      SetScript = {
-        Set-Service -Name Dnscache -StartupType Disabled
-          Stop-Service -Name Dnscache
-      }
-      GetScript = {
-        Get-Service -Name Dnscache
-      }
-      TestScript = {
-        return @(Get-Service -Name Dnscache).Status -eq "Stopped"
-      }
+        SetScript = {
+            Clear-DnsClientCache
+        }
+        GetScript = {
+            Get-DnsClientCache
+        }
+        TestScript = {
+            @(Get-DnsClientCache).Count -eq 0
+        }
+    }
+
+    Registry DisableDNSNegativeCache
+    {
+        Ensure = "Present"
+        Key = "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters"
+        ValueName = "MaxNegativeCacheTtl"
+        ValueType = "DWord"
+        ValueData = "0"
     }
 
     Script EnableDiskQuota


### PR DESCRIPTION
Set the registry entry MaxNegativeCacheTtl to 0
from the setup.ps1 script to avoid caching non
existent DNS reposes returned by a fallback DNS
when consul DNS requests fail intermiytently.

Also clear the DNS cache to make sure that previous
non existent cache entries are purged.

[#107746116]
