### PR TITLE
Only enable PSRemoting if not already

### DIFF
--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -165,7 +165,9 @@ if($PSVersionTable.PSVersion.Major -lt 4) {
   exit(-1)
 }
 
-Enable-PSRemoting -Force
+if (![bool](Test-WSMan -ErrorAction SilentlyContinue)) {
+  Enable-PSRemoting -Force
+}
 Install-WindowsFeature DSC-Service
 CFWindows
 Start-DscConfiguration -Wait -Path .\CFWindows -Force -Verbose


### PR DESCRIPTION
- Allows setup.ps1 to be run via WinRM without resetting the connection because of a forced WinRM service restart.
- Should be slightly faster for systems that already have WinRM enabled.
- Allows advanced users to enable WSMan endpoints for DSC without enabling PSRemoting if desired.
